### PR TITLE
Fix setUserID crash

### DIFF
--- a/ios/NewRelicXamarin.iOS/ApiDefinition.cs
+++ b/ios/NewRelicXamarin.iOS/ApiDefinition.cs
@@ -184,7 +184,7 @@ namespace NewRelicXamarin
         bool SetAttribute(string name, NSObject value);
 
         // +(BOOL)setUserId:(NSString *)userId;
-        [Static, Export("userId:")]
+        [Static, Export("setUserId:")]
         bool setUserId(string userId);
 
         // +(BOOL)incrementAttribute:(NSString *)name;


### PR DESCRIPTION
When calling `NewRelicXamarin.NewRelic.setUserId()` we get the following error:

```
+[NewRelic userId:]: unrecognized selector sent to class 0x1008a9808
```
